### PR TITLE
allow dispatching release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ on:
       - 'AUTHORS'
   release:
     types: [ published ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This allows to manually trigger the release workflow, presumably even on other branches, to regenerate binaries when the workflow for when releasing failed.
This should help with #2757